### PR TITLE
patch: expanded check for Vinyl objects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import Vinyl from 'vinyl';
+import { Buffer } from 'node:buffer';
 import { Transform } from 'node:stream';
 import PluginError from 'plugin-error';
 
@@ -22,7 +23,15 @@ const gulpFillPotPo = (options) => {
   const transformer = new Transform({
     objectMode: true,
     transform(file, encoding, done) {
-      if (!(file instanceof Vinyl)) {
+      if (
+        !(
+          file instanceof Vinyl ||
+          (typeof file === 'object' &&
+            typeof file.contents === 'object' &&
+            file.contents instanceof Buffer &&
+            typeof file.path === 'string')
+        )
+      ) {
         return done(
           new PluginError(PLUGIN_NAME, 'Only Vinyl objects can be transformed.')
         );


### PR DESCRIPTION
* `instanceof Vinyl` is incompatible with previous versions and/or Vinyl constructors used by related gulp plugins. So the guard checks needed adjusting.